### PR TITLE
Rename boundActionCreators to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ const descriptors = [
   …
 ]
 
-exports.onCreateNode = ({ node, boundActionCreators }) => {
-  const { createNodeField } = boundActionCreators
+exports.onCreateNode = ({ node, actions }) => {
+  const { createNodeField } = actions
   attachFields(node, createNodeField, descriptors)
 }
 ```

--- a/lib/onCreateNode.js
+++ b/lib/onCreateNode.js
@@ -12,10 +12,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var onCreateNode = function onCreateNode(_ref, _ref2) {
   var node = _ref.node,
-      boundActionCreators = _ref.boundActionCreators;
+      actions = _ref.actions;
   var context = _ref2.context,
       descriptors = _ref2.descriptors;
-  var createNodeField = boundActionCreators.createNodeField;
+  var createNodeField = actions.createNodeField;
 
   if (descriptors) {
     (0, _attachFields2.default)(node, createNodeField, descriptors, context);

--- a/src/onCreateNode.js
+++ b/src/onCreateNode.js
@@ -1,10 +1,10 @@
 import attachFields from './internal/attachFields'
 
 const onCreateNode = (
-  { node, boundActionCreators },
+  { node, actions },
   { context, descriptors }
 ) => {
-  const { createNodeField } = boundActionCreators
+  const { createNodeField } = actions
   if (descriptors) {
     attachFields(node, createNodeField, descriptors, context)
   }


### PR DESCRIPTION
`boundActionCreators` is [deprecated](https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-boundactioncreators-to-actions) in Gatsby v2. This PR renames it to `actions`